### PR TITLE
usage.md: add an explanation about header-only libs

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -64,7 +64,7 @@ Like Cargo does, Cabin installs dependencies at build time.  Cabin currently sup
 > Here are some links that can help you find header-only libraries:  
 > - https://github.com/topics/single-header  
 > - https://github.com/topics/header-only  
-> - https://p-ranav/awesome-hpp
+> - https://github.com/p-ranav/awesome-hpp
 
 ### `cabin add`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -114,10 +114,6 @@ Downloaded ToruNiina/toml11 846abd9a49082fe51440aa07005c360f13a67bbf
   Finished debug target(s) in 0.70s
 ```
 
-> [!WARNING]
-> Cabin currently supports building a project with header-only dependencies.
-> Building with build-required dependencies will be soon supported.
-
 ## Unit tests
 
 You can write unit tests in any source files within the `src` directory.  Create a new file like:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -52,6 +52,20 @@ Cabin uses a cache since we executed the command with no changes.
 
 Like Cargo does, Cabin installs dependencies at build time.  Cabin currently supports Git, path, and system dependencies.  You can use two ways to add dependencies to your project: using the `cabin add` command and editing `cabin.toml` directly.
 
+> [!WARNING]
+> - Cabin currently supports building a project with header-only dependencies.
+> - Building with build-required dependencies will be soon supported.
+
+> [!NOTE]  
+> A header-only library is a type of library where the entire functionality is contained within header files, and no additional compilation steps are required. This means you can directly include the library's headers in your project without needing to link against any compiled binaries.  
+>  
+> These libraries require the headers to be in the root or include/ directory. This ensures that the library's header files are accessible in a predictable location for easy inclusion in your project.  
+>  
+> Here are some links that can help you find header-only libraries:  
+> - https://github.com/topics/single-header  
+> - https://github.com/topics/header-only  
+> - https://p-ranav/awesome-hpp
+
 ### `cabin add`
 
 The `cabin add` command accepts the following arguments:


### PR DESCRIPTION
usage.md: add an explanation about header-only libraries in the `Install dependencies` section