### PR TITLE
BuildConfig: support PKG_VERSION_NUM

### DIFF
--- a/src/BuildConfig.cc
+++ b/src/BuildConfig.cc
@@ -683,9 +683,9 @@ BuildConfig::setVariables() {
 
   const auto quote = [](auto&& val) {
     if constexpr (std::is_same_v<std::decay_t<decltype(val)>, std::string>) {
-      return fmt::format("'\"{}\"'", val);
+      return fmt::format("'\"{}\"'", std::forward<decltype(val)>(val));
     } else {
-      return fmt::format("{}", val);
+      return fmt::format("{}", std::forward<decltype(val)>(val));
     }
   };
   for (auto&& [key, val] : defines) {

--- a/src/BuildConfig.cc
+++ b/src/BuildConfig.cc
@@ -690,7 +690,7 @@ BuildConfig::setVariables() {
             return fmt::format("{}", val);
           }
         },
-      std::move(val)
+        std::move(val)
     );
     this->defines.push_back(
         fmt::format("-DCABIN_{}_{}={}", pkgName, key, std::move(quoted))

--- a/src/BuildConfig.cc
+++ b/src/BuildConfig.cc
@@ -611,13 +611,6 @@ BuildConfig::installDeps(const bool includeDevDeps) {
 }
 
 void
-BuildConfig::addDefine(
-    const std::string_view name, const std::string_view value
-) {
-  defines.push_back(fmt::format("-D{}='\"{}\"'", name, value));
-}
-
-void
 BuildConfig::setVariables() {
   this->defineSimpleVar("CXX", cxx);
 
@@ -670,25 +663,38 @@ BuildConfig::setVariables() {
   }
 
   // Variables Cabin sets for the user.
-  const std::vector<std::pair<std::string, std::string>> defines{
-    { fmt::format("CABIN_{}_PKG_NAME", pkgName), manifest.package.name },
-    { fmt::format("CABIN_{}_PKG_VERSION", pkgName), pkgVersion.toString() },
-    { fmt::format("CABIN_{}_PKG_VERSION_MAJOR", pkgName),
-      std::to_string(pkgVersion.major) },
-    { fmt::format("CABIN_{}_PKG_VERSION_MINOR", pkgName),
-      std::to_string(pkgVersion.minor) },
-    { fmt::format("CABIN_{}_PKG_VERSION_PATCH", pkgName),
-      std::to_string(pkgVersion.patch) },
-    { fmt::format("CABIN_{}_PKG_VERSION_PRE", pkgName),
-      pkgVersion.pre.toString() },
-    { fmt::format("CABIN_{}_COMMIT_HASH", pkgName), commitHash },
-    { fmt::format("CABIN_{}_COMMIT_SHORT_HASH", pkgName), commitShortHash },
-    { fmt::format("CABIN_{}_COMMIT_DATE", pkgName), commitDate },
-    { fmt::format("CABIN_{}_PROFILE", pkgName),
-      std::string(modeToString(isDebug)) },
+  using DefVal = std::variant<std::string, std::uint64_t>;
+  const auto defValU64 = [](std::uint64_t x) {
+    return DefVal(std::in_place_type<std::uint64_t>, x);
   };
-  for (const auto& [key, val] : defines) {
-    addDefine(key, val);
+
+  std::unordered_map<std::string_view, DefVal> defines;
+  defines.emplace("PKG_NAME", manifest.package.name);
+  defines.emplace("PKG_VERSION", pkgVersion.toString());
+  defines.emplace("PKG_VERSION_MAJOR", defValU64(pkgVersion.major));
+  defines.emplace("PKG_VERSION_MINOR", defValU64(pkgVersion.minor));
+  defines.emplace("PKG_VERSION_PATCH", defValU64(pkgVersion.patch));
+  defines.emplace("PKG_VERSION_PRE", pkgVersion.pre.toString());
+  defines.emplace("PKG_VERSION_NUM", defValU64(pkgVersion.toNum()));
+  defines.emplace("COMMIT_HASH", commitHash);
+  defines.emplace("COMMIT_SHORT_HASH", commitShortHash);
+  defines.emplace("COMMIT_DATE", commitDate);
+  defines.emplace("PROFILE", std::string(modeToString(isDebug)));
+  for (auto&& [key, val] : defines) {
+    std::string quoted = std::visit(
+        [](auto&& val) {
+          if constexpr (std::is_same_v<
+                            std::decay_t<decltype(val)>, std::string>) {
+            return fmt::format("'\"{}\"'", val);
+          } else {
+            return fmt::format("{}", val);
+          }
+        },
+      std::move(val)
+    );
+    this->defines.push_back(
+        fmt::format("-DCABIN_{}_{}={}", pkgName, key, std::move(quoted))
+    );
   }
 
   defineSimpleVar(

--- a/src/BuildConfig.cc
+++ b/src/BuildConfig.cc
@@ -680,18 +680,16 @@ BuildConfig::setVariables() {
   defines.emplace("COMMIT_SHORT_HASH", commitShortHash);
   defines.emplace("COMMIT_DATE", commitDate);
   defines.emplace("PROFILE", std::string(modeToString(isDebug)));
+
+  const auto quote = [](auto&& val) {
+    if constexpr (std::is_same_v<std::decay_t<decltype(val)>, std::string>) {
+      return fmt::format("'\"{}\"'", val);
+    } else {
+      return fmt::format("{}", val);
+    }
+  };
   for (auto&& [key, val] : defines) {
-    std::string quoted = std::visit(
-        [](auto&& val) {
-          if constexpr (std::is_same_v<
-                            std::decay_t<decltype(val)>, std::string>) {
-            return fmt::format("'\"{}\"'", val);
-          } else {
-            return fmt::format("{}", val);
-          }
-        },
-        std::move(val)
-    );
+    std::string quoted = std::visit(quote, std::move(val));
     this->defines.push_back(
         fmt::format("-DCABIN_{}_{}={}", pkgName, key, std::move(quoted))
     );

--- a/src/BuildConfig.hpp
+++ b/src/BuildConfig.hpp
@@ -178,7 +178,6 @@ public:
   Result<bool> containsTestCode(const std::string& sourceFile) const;
 
   Result<void> installDeps(bool includeDevDeps);
-  void addDefine(std::string_view name, std::string_view value);
   void setVariables();
 
   Result<void> processSrc(

--- a/src/Semver.cc
+++ b/src/Semver.cc
@@ -211,6 +211,10 @@ Version::toString() const noexcept {
   }
   return str;
 }
+uint64_t
+Version::toNum() const noexcept {
+  return (major << 32) | (minor << 16) | patch;  // NOLINT(*-magic-numbers)
+}
 
 std::ostream&
 operator<<(std::ostream& os, const Version& ver) noexcept {

--- a/src/Semver.cc
+++ b/src/Semver.cc
@@ -213,6 +213,7 @@ Version::toString() const noexcept {
 }
 uint64_t
 Version::toNum() const noexcept {
+  // 32 bits for major, 16 bits for minor, and 16 bits for patch
   return (major << 32) | (minor << 16) | patch;  // NOLINT(*-magic-numbers)
 }
 

--- a/src/Semver.hpp
+++ b/src/Semver.hpp
@@ -77,6 +77,7 @@ struct Version {
 
   static Result<Version> parse(std::string_view str) noexcept;
   std::string toString() const noexcept;
+  uint64_t toNum() const noexcept;
 };
 std::ostream& operator<<(std::ostream& os, const Version& ver) noexcept;
 bool operator==(const Version& lhs, const Version& rhs) noexcept;


### PR DESCRIPTION
`CABIN_<PKGNAME>_PKG_VERSION_NUM` provides a comparable version number, which is especially useful for library users.