### PR TITLE
Test: fix ignoring test failures

### DIFF
--- a/src/Algos.hpp
+++ b/src/Algos.hpp
@@ -17,7 +17,7 @@ std::string replaceAll(
     std::string str, std::string_view from, std::string_view to
 ) noexcept;
 
-Result<int> execCmd(const Command& cmd) noexcept;
+Result<ExitStatus> execCmd(const Command& cmd) noexcept;
 Result<std::string>
 getCmdOutput(const Command& cmd, std::size_t retry = 3) noexcept;
 bool commandExists(std::string_view cmd) noexcept;

--- a/src/Cmd/Fmt.cc
+++ b/src/Cmd/Fmt.cc
@@ -149,11 +149,11 @@ fmtMain(const CliArgsView args) {
   const Command clangFormat = Command(cabinFmt, std::move(clangFormatArgs))
                                   .setWorkingDirectory(projectPath.string());
 
-  const int exitCode = Try(execCmd(clangFormat));
-  if (exitCode == EXIT_SUCCESS) {
+  const ExitStatus exitStatus = Try(execCmd(clangFormat));
+  if (exitStatus.success()) {
     return Ok();
   } else {
-    Bail("clang-format failed with exit code `{}`", exitCode);
+    Bail("clang-format {}", exitStatus);
   }
 }
 

--- a/src/Cmd/Lint.cc
+++ b/src/Cmd/Lint.cc
@@ -54,11 +54,11 @@ lint(const std::string_view name, const std::vector<std::string>& cpplintArgs) {
   cpplintCmd.addArg("--recursive");
   cpplintCmd.addArg(".");
 
-  const int exitCode = Try(execCmd(cpplintCmd));
-  if (exitCode == EXIT_SUCCESS) {
+  const ExitStatus exitStatus = Try(execCmd(cpplintCmd));
+  if (exitStatus.success()) {
     return Ok();
   } else {
-    Bail("cpplint failed with exit code `{}`", exitCode);
+    Bail("cpplint {}", exitStatus);
   }
 }
 

--- a/src/Cmd/Run.cc
+++ b/src/Cmd/Run.cc
@@ -89,11 +89,11 @@ runMain(const CliArgsView args) {
       manifest.package.name
   );
   const Command command(outDir + "/" + manifest.package.name, runArgs);
-  const int exitCode = Try(execCmd(command));
-  if (exitCode == EXIT_SUCCESS) {
+  const ExitStatus exitStatus = Try(execCmd(command));
+  if (exitStatus.success()) {
     return Ok();
   } else {
-    Bail("run failed with exit code `{}`", exitCode);
+    Bail("run {}", exitStatus);
   }
 }
 

--- a/src/Cmd/Test.cc
+++ b/src/Cmd/Test.cc
@@ -18,11 +18,31 @@
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <utility>
 #include <vector>
 
 namespace cabin {
 
-static Result<void> testMain(CliArgsView args);
+class Test {
+  struct TestArgs {
+    bool isDebug = true;
+  };
+
+  TestArgs args;
+  Manifest manifest;
+  std::string unittestTargetPrefix;
+  std::vector<std::string> unittestTargets;
+
+  Test(TestArgs args, Manifest manifest)
+      : args(args), manifest(std::move(manifest)) {}
+
+  static Result<TestArgs> parseArgs(CliArgsView cliArgs);
+  Result<void> compileTestTargets();
+  Result<void> runTestTargets();
+
+public:
+  static Result<void> exec(CliArgsView cliArgs);
+};
 
 const Subcmd TEST_CMD =  //
     Subcmd{ "test" }
@@ -31,30 +51,27 @@ const Subcmd TEST_CMD =  //
         .addOpt(OPT_DEBUG)
         .addOpt(OPT_RELEASE)
         .addOpt(OPT_JOBS)
-        .setMainFn(testMain);
+        .setMainFn(Test::exec);
 
-static Result<void>
-testMain(const CliArgsView args) {
-  // Parse args
-  bool isDebug = true;
-  for (auto itr = args.begin(); itr != args.end(); ++itr) {
+Result<Test::TestArgs>
+Test::parseArgs(const CliArgsView cliArgs) {
+  TestArgs args;
+
+  for (auto itr = cliArgs.begin(); itr != cliArgs.end(); ++itr) {
     const std::string_view arg = *itr;
 
-    const auto control = Try(Cli::handleGlobalOpts(itr, args.end(), "test"));
+    const auto control = Try(Cli::handleGlobalOpts(itr, cliArgs.end(), "test"));
     if (control == Cli::Return) {
-      return Ok();
+      return Ok(args);
     } else if (control == Cli::Continue) {
       continue;
     } else if (arg == "-d" || arg == "--debug") {
-      isDebug = true;
+      args.isDebug = true;
     } else if (arg == "-r" || arg == "--release") {
-      logger::warn(
-          "Tests in release mode could disable assert macros while speeding up "
-          "the runtime."
-      );
-      isDebug = false;
+      logger::warn("Tests in release mode possibly disables assert macros.");
+      args.isDebug = false;
     } else if (arg == "-j" || arg == "--jobs") {
-      if (itr + 1 == args.end()) {
+      if (itr + 1 == cliArgs.end()) {
         return Subcmd::missingOptArgumentFor(arg);
       }
       const std::string_view nextArg = *++itr;
@@ -70,16 +87,18 @@ testMain(const CliArgsView args) {
     }
   }
 
+  return Ok(args);
+}
+
+Result<void>
+Test::compileTestTargets() {
   const auto start = std::chrono::steady_clock::now();
 
-  const auto manifest = Try(Manifest::tryParse());
   const BuildConfig config =
-      Try(emitMakefile(manifest, isDebug, /*includeDevDeps=*/true));
+      Try(emitMakefile(manifest, args.isDebug, /*includeDevDeps=*/true));
 
   // Collect test targets from the generated Makefile.
-  const std::string unittestTargetPrefix =
-      (config.outBasePath / "unittests").string() + '/';
-  std::vector<std::string> unittestTargets;
+  unittestTargetPrefix = (config.outBasePath / "unittests").string() + '/';
   std::ifstream infile(config.outBasePath / "Makefile");
   std::string line;
   while (std::getline(infile, line)) {
@@ -103,12 +122,12 @@ testMain(const CliArgsView args) {
 
   // Find not up-to-date test targets, emit compilation status once, and
   // compile them.
-  int exitCode{};
+  ExitStatus exitStatus;
   bool alreadyEmitted = false;
   for (const std::string& target : unittestTargets) {
     Command checkUpToDateCmd = baseMakeCmd;
     checkUpToDateCmd.addArg("--question").addArg(target);
-    if (Try(execCmd(checkUpToDateCmd)) != EXIT_SUCCESS) {
+    if (!Try(execCmd(checkUpToDateCmd)).success()) {
       // This test target is not up-to-date.
       if (!alreadyEmitted) {
         logger::info(
@@ -121,18 +140,35 @@ testMain(const CliArgsView args) {
 
       Command testCmd = baseMakeCmd;
       testCmd.addArg(target);
-      const int curExitCode = Try(execCmd(testCmd));
-      if (curExitCode != EXIT_SUCCESS) {
-        exitCode = curExitCode;
+      const ExitStatus curExitStatus = Try(execCmd(testCmd));
+      if (!curExitStatus.success()) {
+        exitStatus = curExitStatus;
       }
     }
   }
-  if (exitCode != EXIT_SUCCESS) {
-    // Compilation failed; don't proceed to run tests.
-    Bail("compilation failed");
-  }
+  // If the compilation failed, don't proceed to run tests.
+  Ensure(exitStatus.success(), "compilation failed");
 
-  // Run tests.
+  const auto end = std::chrono::steady_clock::now();
+  const std::chrono::duration<double> elapsed = end - start;
+
+  const Profile& profile = args.isDebug ? manifest.profiles.at("dev")
+                                        : manifest.profiles.at("release");
+  logger::info(
+      "Finished", "`{}` profile [{}] target(s) in {:.2f}s",
+      modeToProfile(args.isDebug), profile.toString(), elapsed.count()
+  );
+
+  return Ok();
+}
+
+Result<void>
+Test::runTestTargets() {
+  const auto start = std::chrono::steady_clock::now();
+
+  std::size_t numPassed = 0;
+  std::size_t numFailed = 0;
+  ExitStatus exitStatus;
   for (const std::string& target : unittestTargets) {
     // `target` always starts with "unittests/" and ends with ".test".
     // We need to replace "unittests/" with "src/" and remove ".test" to get
@@ -145,20 +181,42 @@ testMain(const CliArgsView args) {
         fs::relative(target, manifest.path.parent_path()).string();
     logger::info("Running", "unittests {} ({})", sourcePath, testBinPath);
 
-    const int curExitCode = Try(execCmd(Command(target)));
-    if (curExitCode != EXIT_SUCCESS) {
-      exitCode = curExitCode;
+    const ExitStatus curExitStatus = Try(execCmd(Command(target)));
+    if (curExitStatus.success()) {
+      ++numPassed;
+    } else {
+      ++numFailed;
+      exitStatus = curExitStatus;
     }
   }
 
   const auto end = std::chrono::steady_clock::now();
   const std::chrono::duration<double> elapsed = end - start;
 
-  if (exitCode == EXIT_SUCCESS) {
-    logger::info(
-        "Finished", "{} test(s) in {}s", modeToString(isDebug), elapsed.count()
-    );
+  // TODO: collect stdout/err's of failed tests and print them here.
+  const std::string summary = fmt::format(
+      "{} passed; {} failed; finished in {:.2f}s", numPassed, numFailed,
+      elapsed.count()
+  );
+  if (!exitStatus.success()) {
+    return Err(anyhow::anyhow(summary));
   }
+  logger::info("Ok", "{}", summary);
+  return Ok();
+}
+
+Result<void>
+Test::exec(const CliArgsView cliArgs) {
+  const TestArgs args = Try(parseArgs(cliArgs));
+  Manifest manifest = Try(Manifest::tryParse());
+  Test cmd(args, std::move(manifest));
+
+  Try(cmd.compileTestTargets());
+  if (cmd.unittestTargets.empty()) {
+    return Ok();
+  }
+
+  Try(cmd.runTestTargets());
   return Ok();
 }
 

--- a/src/Cmd/Tidy.cc
+++ b/src/Cmd/Tidy.cc
@@ -32,16 +32,16 @@ static Result<void>
 tidyImpl(const Command& makeCmd) {
   const auto start = std::chrono::steady_clock::now();
 
-  const int exitCode = Try(execCmd(makeCmd));
+  const ExitStatus exitStatus = Try(execCmd(makeCmd));
 
   const auto end = std::chrono::steady_clock::now();
   const std::chrono::duration<double> elapsed = end - start;
 
-  if (exitCode == EXIT_SUCCESS) {
+  if (exitStatus.success()) {
     logger::info("Finished", "clang-tidy in {}s", elapsed.count());
     return Ok();
   }
-  Bail("clang-tidy failed with exit code `{}`", exitCode);
+  Bail("clang-tidy {}", exitStatus);
 }
 
 static Result<void>

--- a/src/Command.cc
+++ b/src/Command.cc
@@ -17,7 +17,7 @@ namespace cabin {
 
 constexpr std::size_t BUFFER_SIZE = 128;
 
-Result<int>
+Result<ExitStatus>
 Child::wait() const noexcept {
   int status{};
   if (waitpid(pid, &status, 0) == -1) {
@@ -37,8 +37,7 @@ Child::wait() const noexcept {
     close(stdErrFd);
   }
 
-  const int exitCode = WEXITSTATUS(status);
-  return Ok(exitCode);
+  return Ok(ExitStatus{ status });
 }
 
 Result<CommandOutput>
@@ -121,10 +120,9 @@ Child::waitWithOutput() const noexcept {
   if (waitpid(pid, &status, 0) == -1) {
     Bail("waitpid() failed");
   }
-
-  const int exitCode = WEXITSTATUS(status);
-  return Ok(CommandOutput{
-      .exitCode = exitCode, .stdOut = stdOutOutput, .stdErr = stdErrOutput });
+  return Ok(CommandOutput{ .exitStatus = ExitStatus{ status },
+                           .stdOut = stdOutOutput,
+                           .stdErr = stdErrOutput });
 }
 
 Result<Child>

--- a/src/Command.hpp
+++ b/src/Command.hpp
@@ -3,19 +3,77 @@
 #include "Rustify/Result.hpp"
 
 #include <cstdint>
+#include <cstdlib>
 #include <filesystem>
+#include <fmt/core.h>
+#include <fmt/ostream.h>
 #include <ostream>
 #include <span>
 #include <string>
 #include <string_view>
 #include <sys/types.h>
+#include <sys/wait.h>
 #include <utility>
 #include <vector>
 
 namespace cabin {
 
+class ExitStatus {
+  int rawStatus;  // Original status from waitpid
+
+public:
+  ExitStatus() noexcept : rawStatus(EXIT_SUCCESS) {}
+  explicit ExitStatus(int status) noexcept : rawStatus(status) {}
+
+  bool exitedNormally() const noexcept {
+    return WIFEXITED(rawStatus);
+  }
+  bool killedBySignal() const noexcept {
+    return WIFSIGNALED(rawStatus);
+  }
+  bool stoppedBySignal() const noexcept {
+    return WIFSTOPPED(rawStatus);
+  }
+  int exitCode() const noexcept {
+    return WEXITSTATUS(rawStatus);
+  }
+  int termSignal() const noexcept {
+    return WTERMSIG(rawStatus);
+  }
+  int stopSignal() const noexcept {
+    return WSTOPSIG(rawStatus);
+  }
+  bool coreDumped() const noexcept {
+    return WCOREDUMP(rawStatus);
+  }
+
+  // Successful only if normally exited with code 0
+  bool success() const noexcept {
+    return exitedNormally() && exitCode() == 0;
+  }
+
+  std::string toString() const {
+    if (exitedNormally()) {
+      return fmt::format("exited with code {}", exitCode());
+    } else if (killedBySignal()) {
+      return fmt::format(
+          "killed by signal {}{}", termSignal(),
+          coreDumped() ? " (core dumped)" : ""
+      );
+    } else if (stoppedBySignal()) {
+      return fmt::format("stopped by signal {}", stopSignal());
+    }
+    return "unknown status";
+  }
+
+  friend std::ostream& operator<<(std::ostream& os, const ExitStatus& status) {
+    os << status.toString();
+    return os;
+  }
+};
+
 struct CommandOutput {
-  const int exitCode;
+  const ExitStatus exitStatus;
   const std::string stdOut;
   const std::string stdErr;
 };
@@ -32,7 +90,7 @@ private:
   friend struct Command;
 
 public:
-  Result<int> wait() const noexcept;
+  Result<ExitStatus> wait() const noexcept;
   Result<CommandOutput> waitWithOutput() const noexcept;
 };
 
@@ -84,3 +142,6 @@ struct Command {
 std::ostream& operator<<(std::ostream& os, const Command& cmd);
 
 }  // namespace cabin
+
+template <>
+struct fmt::formatter<cabin::ExitStatus> : ostream_formatter {};

--- a/src/Manifest.hpp
+++ b/src/Manifest.hpp
@@ -4,10 +4,10 @@
 #include "Semver.hpp"
 #include "VersionReq.hpp"
 
-#include <compare>
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
+#include <fmt/ranges.h>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -94,8 +94,21 @@ struct Profile {
            && optLevel == other.optLevel;
   }
 
-  friend std::ostream& operator<<(std::ostream& os, const Profile& p) {
-    const std::string str = fmt::format(
+  std::string toString() const {
+    std::vector<std::string_view> strs;
+    if (optLevel == 0) {
+      strs.emplace_back("unoptimized");
+    } else {
+      strs.emplace_back("optimized");
+    }
+    if (debug) {
+      strs.emplace_back("debuginfo");
+    }
+    return fmt::format("{}", fmt::join(strs, " + "));
+  }
+
+  std::string toDebugString() const {
+    return fmt::format(
         R"(Profile {{
   cxxflags: {},
   ldflags: {},
@@ -104,9 +117,12 @@ struct Profile {
   compDb: {},
   optLevel: {},
 }})",
-        p.cxxflags, p.ldflags, p.lto, p.debug, p.compDb, p.optLevel
+        cxxflags, ldflags, lto, debug, compDb, optLevel
     );
-    os << str;
+  }
+
+  friend std::ostream& operator<<(std::ostream& os, const Profile& p) {
+    os << p.toDebugString();
     return os;
   }
 };

--- a/src/Rustify/Tests.hpp
+++ b/src/Rustify/Tests.hpp
@@ -70,7 +70,7 @@ inline void
 pass(
     const std::source_location& loc = std::source_location::current()
 ) noexcept {
-  std::cout << "      test " << getModName(loc.file_name())
+  std::cout << "        test " << getModName(loc.file_name())
             << "::" << prettifyFuncName(loc.function_name()) << " ... " << GREEN
             << "ok" << RESET << '\n'
             << std::flush;
@@ -79,7 +79,7 @@ pass(
 [[noreturn]] inline void
 error(const std::source_location& loc, Display auto&&... msgs) {
   std::ostringstream oss;
-  oss << "\n      test " << getModName(loc.file_name())
+  oss << "\n        test " << getModName(loc.file_name())
       << "::" << prettifyFuncName(loc.function_name()) << " ... " << RED
       << "FAILED" << RESET << "\n\n"
       << '\'' << prettifyFuncName(loc.function_name()) << "' failed at '"


### PR DESCRIPTION
This patch fixes an issue where test command ignores test failures due to the incorrect exit status handling.  This patch includes some interface improvements as well.