### PR TITLE
refactor: remove unnecessary fs::path::string() calls

### DIFF
--- a/src/BuildConfig.cc
+++ b/src/BuildConfig.cc
@@ -733,7 +733,7 @@ BuildConfig::configureBuild() {
           "`src/` directory. "
           "This file will not be treated as the program's entry point. "
           "Move it directly to 'src/' if intended as such.",
-          sourceFilePath.string()
+          sourceFilePath
       );
     } else if (sourceFilePath != libSource && isLibSource(sourceFilePath)) {
       Diag::warn(
@@ -741,11 +741,11 @@ BuildConfig::configureBuild() {
           "`src/` directory. "
           "This file will not be treated as a hasLibraryTarget. "
           "Move it directly to 'src/' if intended as such.",
-          sourceFilePath.string()
+          sourceFilePath
       );
     }
 
-    srcs += ' ' + sourceFilePath.string();
+    srcs += fmt::format(" {}", sourceFilePath);
   }
 
   defineSimpleVar("SRCS", srcs);
@@ -1041,4 +1041,5 @@ main() {
   // tests::testSimpleTargets();
   // tests::testDependOnUnregisteredTarget();
 }
+
 #endif

--- a/src/Builder/Compiler.hpp
+++ b/src/Builder/Compiler.hpp
@@ -141,9 +141,9 @@ struct fmt::formatter<cabin::IncludeDir> {
   template <typename FormatContext>
   auto format(const cabin::IncludeDir& id, FormatContext& ctx) const {
     if (id.isSystem) {
-      return fmt::format_to(ctx.out(), "-isystem{}", id.dir.string());
+      return fmt::format_to(ctx.out(), "-isystem{}", id.dir);
     }
-    return fmt::format_to(ctx.out(), "-I{}", id.dir.string());
+    return fmt::format_to(ctx.out(), "-I{}", id.dir);
   }
 };
 
@@ -172,7 +172,7 @@ struct fmt::formatter<cabin::LibDir> {
 
   template <typename FormatContext>
   auto format(const cabin::LibDir& ld, FormatContext& ctx) const {
-    return fmt::format_to(ctx.out(), "-L{}", ld.dir.string());
+    return fmt::format_to(ctx.out(), "-L{}", ld.dir);
   }
 };
 

--- a/src/Cmd/Build.cc
+++ b/src/Cmd/Build.cc
@@ -51,8 +51,7 @@ runBuildCommand(
     // If `targetName` is not up-to-date, compile it.
     Diag::info(
         "Compiling", "{} v{} ({})", targetName,
-        manifest.package.version.toString(),
-        manifest.path.parent_path().string()
+        manifest.package.version.toString(), manifest.path.parent_path()
     );
     exitStatus = Try(execCmd(makeCmd));
   }

--- a/src/Cmd/Clean.cc
+++ b/src/Cmd/Clean.cc
@@ -53,7 +53,7 @@ cleanMain(CliArgsView args) noexcept {
   }
 
   if (fs::exists(outDir)) {
-    Diag::info("Removing", "{}", fs::canonical(outDir).string());
+    Diag::info("Removing", "{}", fs::canonical(outDir));
     fs::remove_all(outDir);
   }
   return Ok();

--- a/src/Cmd/Fmt.cc
+++ b/src/Cmd/Fmt.cc
@@ -71,7 +71,7 @@ collectFormatTargets(
       const fs::path path = fs::relative(entry->path(), manifestDir);
       if ((hasGitRepo && repo.isIgnored(path.string()))
           || isExcluded(path.string())) {
-        spdlog::debug("Ignore: {}", path.string());
+        spdlog::debug("Ignore: {}", path);
         continue;
       }
 

--- a/src/Cmd/New.cc
+++ b/src/Cmd/New.cc
@@ -88,7 +88,7 @@ writeToFile(
   ofs.close();
 
   if (!ofs) {
-    Bail("writing `{}` failed", fpath.string());
+    Bail("writing `{}` failed", fpath);
   }
   ofs.clear();
   return Ok();

--- a/src/Cmd/Remove.cc
+++ b/src/Cmd/Remove.cc
@@ -44,7 +44,7 @@ removeMain(const CliArgsView args) {
     } else {
       // manifestPath needs to be converted to string
       // or it adds extra quotes around the path
-      Diag::warn("Dependency `{}` not found in {}", dep, manifestPath.string());
+      Diag::warn("Dependency `{}` not found in {}", dep, manifestPath);
     }
   }
 
@@ -52,8 +52,7 @@ removeMain(const CliArgsView args) {
     std::ofstream out(manifestPath);
     out << data;
     Diag::info(
-        "Removed", "{} from {}", fmt::join(removedDeps, ", "),
-        manifestPath.string()
+        "Removed", "{} from {}", fmt::join(removedDeps, ", "), manifestPath
     );
   }
   return Ok();

--- a/src/Cmd/Run.cc
+++ b/src/Cmd/Run.cc
@@ -84,8 +84,7 @@ runMain(const CliArgsView args) {
   Try(buildImpl(manifest, outDir, isDebug));
 
   Diag::info(
-      "Running", "`{}/{}`",
-      fs::relative(outDir, manifest.path.parent_path()).string(),
+      "Running", "`{}/{}`", fs::relative(outDir, manifest.path.parent_path()),
       manifest.package.name
   );
   const Command command(outDir + "/" + manifest.package.name, runArgs);

--- a/src/Cmd/Test.cc
+++ b/src/Cmd/Test.cc
@@ -132,8 +132,7 @@ Test::compileTestTargets() {
       if (!alreadyEmitted) {
         Diag::info(
             "Compiling", "{} v{} ({})", manifest.package.name,
-            manifest.package.version.toString(),
-            manifest.path.parent_path().string()
+            manifest.package.version.toString(), manifest.path.parent_path()
         );
         alreadyEmitted = true;
       }
@@ -178,8 +177,8 @@ Test::runTestTargets() {
     sourcePath.replace(0, unittestTargetPrefix.size(), "src/");
     sourcePath.resize(sourcePath.size() - ".test"sv.size());
 
-    const std::string testBinPath =
-        fs::relative(target, manifest.path.parent_path()).string();
+    const fs::path testBinPath =
+        fs::relative(target, manifest.path.parent_path());
     Diag::info("Running", "unittests {} ({})", sourcePath, testBinPath);
 
     const ExitStatus curExitStatus = Try(execCmd(Command(target)));

--- a/src/Dependency.cc
+++ b/src/Dependency.cc
@@ -75,7 +75,7 @@ PathDependency::install() const {
   if (fs::exists(installDir) && !fs::is_empty(installDir)) {
     spdlog::debug("{} is already installed", name);
   } else {
-    Bail("{} can't be accessible as directory", installDir.string());
+    Bail("{} can't be accessible as directory", installDir);
   }
 
   const fs::path includeDir = installDir / "include";

--- a/src/Manifest.cc
+++ b/src/Manifest.cc
@@ -397,7 +397,7 @@ Manifest::findPath(fs::path candidateDir) noexcept {
   const fs::path origCandDir = candidateDir;
   while (true) {
     const fs::path configPath = candidateDir / FILE_NAME;
-    spdlog::trace("Finding manifest: {}", configPath.string());
+    spdlog::trace("Finding manifest: {}", configPath);
     if (fs::exists(configPath)) {
       return Ok(configPath);
     }
@@ -411,7 +411,7 @@ Manifest::findPath(fs::path candidateDir) noexcept {
     }
   }
 
-  Bail("{} not find in `{}` and its parents", FILE_NAME, origCandDir.string());
+  Bail("{} not find in `{}` and its parents", FILE_NAME, origCandDir);
 }
 
 Result<std::vector<CompilerOptions>>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined file path handling in log and error messages across build, clean, run, test, and dependency operations.
  - Updated formatting for directory and file outputs to provide a more consistent and clear user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->