### PR TITLE
Builder: add BuildProfile & debug -> dev

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -102,12 +102,12 @@ jobs:
         run: ./build/cabin --verbose run test --verbose
 
       - name: Stage 2 - Print version
-        run: ./cabin-out/debug/cabin version --verbose
+        run: ./cabin-out/dev/cabin version --verbose
 
       - name: Stage 2 - Integration Test
         run: find tests -maxdepth 1 -name '[0-9]*.sh' -print0 | xargs -0 -I {} sh -c 'sh {} -v'
         env:
-          CABIN: ${{ github.workspace }}/cabin-out/debug/cabin
+          CABIN: ${{ github.workspace }}/cabin-out/dev/cabin
           CABIN_TERM_COLOR: auto
 
       # - name: Print coverage

--- a/docs/hello-world.md
+++ b/docs/hello-world.md
@@ -18,7 +18,7 @@ you:~$ cd hello_world
 you:~/hello_world$ cabin run
  Compiling src/main.cc
    Linking hello_world
-  Finished debug target(s) in 0.45386s
-   Running cabin-out/debug/hello_world
+  Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.45386s
+   Running cabin-out/dev/hello_world
 Hello, world!
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -27,8 +27,8 @@ In most cases, you want to execute the generated binary as well as build the pro
 you:~/hello_world$ cabin run
  Compiling src/main.cc
    Linking hello_world
-  Finished debug target(s) in 0.45386s
-   Running cabin-out/debug/hello_world
+  Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.45386s
+   Running cabin-out/dev/hello_world
 Hello, world!
 ```
 
@@ -36,7 +36,7 @@ If you just want to build it, run the `build` command:
 
 ```console
 you:~/hello_world$ cabin build
-  Finished debug target(s) in 0.00866317s
+  Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.00866317s
 ```
 
 Cabin uses a cache since we executed the command with no changes.
@@ -111,7 +111,7 @@ you:~/hello_world$ cabin build
 Downloaded ToruNiina/toml11 846abd9a49082fe51440aa07005c360f13a67bbf
  Compiling src/main.cc
    Linking hello_world
-  Finished debug target(s) in 0.70s
+  Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.70s
 ```
 
 ### Remove dependencies

--- a/src/BuildConfig.hpp
+++ b/src/BuildConfig.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "./Builder/Project.hpp"
+#include "Builder/BuildProfile.hpp"
+#include "Builder/Project.hpp"
 #include "Command.hpp"
 #include "Manifest.hpp"
 
@@ -59,7 +60,7 @@ private:
   std::string libName;
   fs::path buildOutPath;
   fs::path unittestOutPath;
-  bool isDebug;
+  BuildProfile buildProfile;
 
   // if we are building an binary
   bool hasBinaryTarget{ false };
@@ -81,18 +82,18 @@ private:
   ) const;
 
   explicit BuildConfig(
-      const Manifest& manifest, bool isDebug, std::string libName,
+      const Manifest& manifest, BuildProfile buildProfile, std::string libName,
       fs::path outBasePath, fs::path buildOutPath, fs::path unittestOutPath,
       Project project
   )
       : outBasePath(std::move(outBasePath)), manifest(manifest),
         libName(std::move(libName)), buildOutPath(std::move(buildOutPath)),
-        unittestOutPath(std::move(unittestOutPath)), isDebug(isDebug),
-        project(std::move(project)) {}
+        unittestOutPath(std::move(unittestOutPath)),
+        buildProfile(std::move(buildProfile)), project(std::move(project)) {}
 
 public:
   static Result<BuildConfig>
-  init(const Manifest& manifest, bool isDebug = true);
+  init(const Manifest& manifest, BuildProfile buildProfile = BuildProfile::Dev);
 
   bool hasBinTarget() const {
     return hasBinaryTarget;
@@ -212,12 +213,14 @@ public:
   Result<void> configureBuild();
 };
 
-Result<BuildConfig>
-emitMakefile(const Manifest& manifest, bool isDebug, bool includeDevDeps);
-Result<std::string>
-emitCompdb(const Manifest& manifest, bool isDebug, bool includeDevDeps);
-std::string_view modeToString(bool isDebug);
-const char* modeToProfile(bool isDebug);
+Result<BuildConfig> emitMakefile(
+    const Manifest& manifest, const BuildProfile& buildProfile,
+    bool includeDevDeps
+);
+Result<std::string> emitCompdb(
+    const Manifest& manifest, const BuildProfile& buildProfile,
+    bool includeDevDeps
+);
 Command getMakeCommand();
 
 }  // namespace cabin

--- a/src/Builder/BuildProfile.hpp
+++ b/src/Builder/BuildProfile.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <fmt/format.h>
+#include <string>
+#include <utility>
+#include <variant>
+
+namespace cabin {
+
+class BuildProfile {
+  friend struct fmt::formatter<BuildProfile>;
+  friend struct std::hash<BuildProfile>;
+
+public:
+  enum Type : uint8_t {
+    Dev,
+    Release,
+  };
+
+private:
+  using TypeT = std::variant<Type, std::string>;
+  TypeT type;
+
+public:
+  BuildProfile() : type(Type::Dev) {}
+  BuildProfile(Type type) : type(type) {}  // NOLINT
+  explicit BuildProfile(std::string type) : type(std::move(type)) {}
+
+  bool operator==(const BuildProfile& other) const {
+    return type == other.type;
+  }
+};
+
+}  // namespace cabin
+
+template <>
+struct std::hash<cabin::BuildProfile> {
+  std::size_t operator()(const cabin::BuildProfile& bp) const noexcept {
+    return std::hash<cabin::BuildProfile::TypeT>{}(bp.type);
+  }
+};
+
+template <>
+struct fmt::formatter<cabin::BuildProfile> {
+  // NOLINTNEXTLINE(*-static)
+  constexpr auto parse(fmt::format_parse_context& ctx) {
+    return ctx.begin();
+  }
+
+  template <typename FormatContext>
+  auto
+  format(const cabin::BuildProfile& buildProfile, FormatContext& ctx) const {
+    if (std::holds_alternative<cabin::BuildProfile::Type>(buildProfile.type)) {
+      switch (std::get<cabin::BuildProfile::Type>(buildProfile.type)) {
+        case cabin::BuildProfile::Dev:
+          return fmt::format_to(ctx.out(), "dev");
+        case cabin::BuildProfile::Release:
+          return fmt::format_to(ctx.out(), "release");
+      }
+      __builtin_unreachable();
+    } else {
+      return fmt::format_to(
+          ctx.out(), "{}", std::get<std::string>(buildProfile.type)
+      );
+    }
+  }
+};

--- a/src/Builder/Project.cc
+++ b/src/Builder/Project.cc
@@ -4,6 +4,7 @@
 #include "../Git2.hpp"
 #include "../Rustify/Result.hpp"
 #include "../TermColor.hpp"
+#include "BuildProfile.hpp"
 
 #include <filesystem>
 #include <spdlog/spdlog.h>
@@ -98,8 +99,8 @@ getEnvFlags(const char* name) {
 }
 
 void
-Project::setBuildProfile(const bool isDebug) {
-  const Profile& profile = manifest.profiles.at(isDebug ? "dev" : "release");
+Project::setBuildProfile(const BuildProfile& buildProfile) {
+  const Profile& profile = manifest.profiles.at(buildProfile);
   if (profile.debug) {
     compiler.opts.cFlags.others.emplace_back("-g");
     compiler.opts.cFlags.macros.emplace_back("DEBUG", "");
@@ -154,7 +155,7 @@ Project::setBuildProfile(const bool isDebug) {
   defines.emplace("COMMIT_HASH", commitHash);
   defines.emplace("COMMIT_SHORT_HASH", commitShortHash);
   defines.emplace("COMMIT_DATE", commitDate);
-  defines.emplace("PROFILE", std::string(isDebug ? "dev" : "release"));
+  defines.emplace("PROFILE", fmt::format("{}", buildProfile));
 
   const auto quote = [](auto&& val) {
     if constexpr (std::is_same_v<std::decay_t<decltype(val)>, std::string>) {

--- a/src/Builder/Project.hpp
+++ b/src/Builder/Project.hpp
@@ -2,6 +2,7 @@
 
 #include "../Manifest.hpp"
 #include "../Rustify/Result.hpp"
+#include "BuildProfile.hpp"
 #include "Compiler.hpp"
 
 #include <filesystem>
@@ -21,7 +22,7 @@ public:
 
   static Result<Project> init(const fs::path& rootDir);
 
-  void setBuildProfile(bool isDebug);
+  void setBuildProfile(const BuildProfile& buildProfile);
 };
 
 }  // namespace cabin

--- a/src/Cmd/Build.hpp
+++ b/src/Cmd/Build.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../Builder/BuildProfile.hpp"
 #include "../Cli.hpp"
 #include "../Manifest.hpp"
 #include "../Rustify/Result.hpp"
@@ -9,7 +10,8 @@
 namespace cabin {
 
 extern const Subcmd BUILD_CMD;
-Result<void>
-buildImpl(const Manifest& manifest, std::string& outDir, bool isDebug);
+Result<void> buildImpl(
+    const Manifest& manifest, std::string& outDir, const BuildProfile& profile
+);
 
 }  // namespace cabin

--- a/src/Cmd/Clean.cc
+++ b/src/Cmd/Clean.cc
@@ -42,7 +42,7 @@ cleanMain(CliArgsView args) noexcept {
       }
 
       const std::string_view nextArg = *++itr;
-      if (!(nextArg == "debug" || nextArg == "release")) {
+      if (!(nextArg == "dev" || nextArg == "release")) {
         Bail("Invalid argument for {}: {}", arg, nextArg);
       }
 

--- a/src/Cmd/Common.hpp
+++ b/src/Cmd/Common.hpp
@@ -5,9 +5,6 @@
 
 namespace cabin {
 
-inline constinit const Opt OPT_DEBUG = Opt{ "--debug" }.setShort("-d").setDesc(
-    "Build with debug information [default]"
-);
 inline constinit const Opt OPT_RELEASE =
     Opt{ "--release" }.setShort("-r").setDesc("Build with optimizations");
 

--- a/src/Cmd/Tidy.cc
+++ b/src/Cmd/Tidy.cc
@@ -2,6 +2,7 @@
 
 #include "../Algos.hpp"
 #include "../BuildConfig.hpp"
+#include "../Builder/BuildProfile.hpp"
 #include "../Cli.hpp"
 #include "../Command.hpp"
 #include "../Diag.hpp"
@@ -86,14 +87,14 @@ tidyMain(const CliArgsView args) {
 
   const auto manifest = Try(Manifest::tryParse());
   const BuildConfig config =
-      Try(emitMakefile(manifest, /*isDebug=*/true, /*includeDevDeps=*/false));
+      Try(emitMakefile(manifest, BuildProfile::Dev, /*includeDevDeps=*/false));
 
   std::string tidyFlags = "CABIN_TIDY_FLAGS=";
   if (!isVerbose()) {
     tidyFlags += "-quiet";
   }
   if (fs::exists(".clang-tidy")) {
-    // clang-tidy will run within the cabin-out/debug directory.
+    // clang-tidy will run within the cabin-out/dev directory.
     tidyFlags += " --config-file=../../.clang-tidy";
   }
   if (fix) {

--- a/src/Manifest.hpp
+++ b/src/Manifest.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Builder/BuildProfile.hpp"
 #include "Builder/Compiler.hpp"
 #include "Dependency.hpp"
 #include "Rustify/Result.hpp"
@@ -121,7 +122,7 @@ public:
   const Package package;
   const std::vector<Dependency> dependencies;
   const std::vector<Dependency> devDependencies;
-  const std::unordered_map<std::string, Profile> profiles;
+  const std::unordered_map<BuildProfile, Profile> profiles;
   const Lint lint;
 
   static Result<Manifest> tryParse(
@@ -139,7 +140,7 @@ private:
   Manifest(
       fs::path path, Package package, std::vector<Dependency> dependencies,
       std::vector<Dependency> devDependencies,
-      std::unordered_map<std::string, Profile> profiles, Lint lint
+      std::unordered_map<BuildProfile, Profile> profiles, Lint lint
   ) noexcept
       : path(std::move(path)), package(std::move(package)),
         dependencies(std::move(dependencies)),
@@ -154,7 +155,7 @@ Result<void> validatePackageName(std::string_view name) noexcept;
 template <>
 struct fmt::formatter<cabin::Profile> {
 private:
-  bool debug = false;
+  bool debugFmt = false;
 
 public:
   constexpr auto parse(fmt::format_parse_context& ctx) {
@@ -165,7 +166,7 @@ public:
     }
 
     if (*itr == '?') {
-      debug = true;
+      debugFmt = true;
       ++itr;  // NOLINT
     }
     return itr;
@@ -173,7 +174,7 @@ public:
 
   template <typename FormatContext>
   auto format(const cabin::Profile& p, FormatContext& ctx) const {
-    if (!debug) {
+    if (!debugFmt) {
       std::vector<std::string_view> strs;
       if (p.optLevel == 0) {
         strs.emplace_back("unoptimized");

--- a/tests/06-run.sh
+++ b/tests/06-run.sh
@@ -14,15 +14,15 @@ test_expect_success 'cabin run hello_world' '
     "$CABIN" run 1>stdout 2>stderr &&
     (
         test -d cabin-out &&
-        test -d cabin-out/debug &&
-        test -x cabin-out/debug/hello_world
+        test -d cabin-out/dev &&
+        test -x cabin-out/dev/hello_world
     ) &&
     (
         TIME=$(cat stderr | grep Finished | grep -o '\''[0-9]\+\.[0-9]\+'\'') &&
         cat >stderr_exp <<-EOF &&
    Compiling hello_world v0.1.0 ($(realpath $OUT)/hello_world)
     Finished \`dev\` profile [unoptimized + debuginfo] target(s) in ${TIME}s
-     Running \`cabin-out/debug/hello_world\`
+     Running \`cabin-out/dev/hello_world\`
 EOF
         test_cmp stderr_exp stderr
     ) &&


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated usage guides and output messages to reflect the change from “debug” to “dev” in build and run commands.
  - Revised directory references in documentation for improved clarity.

- **New Features**
  - Streamlined command-line behavior: the default build now uses a “dev” profile with release mode selectable via updated options.
  - Adjusted workflow settings and output paths to align with the new build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->