### PR TITLE
deps: bump toml11 to v4.4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ NLOHMANN_JSON_VERREQ := nlohmann_json >= 3.10.5, nlohmann_json < 4.0.0
 TBB_VERREQ := tbb >= 2021.5.0, tbb < 2023.0.0
 FMT_VERREQ := fmt >= 9.0.0, fmt < 12.0.0
 SPDLOG_VERREQ := spdlog >= 1.8.0, spdlog < 2.0.0
-TOML11_VER := $(shell grep -m1 toml11 cabin.toml | sed 's/.*rev = \(.*\)}/\1/' | tr -d '"')
+TOML11_VER := $(shell grep -m1 toml11 cabin.toml | sed 's/.*tag = \(.*\)}/\1/' | tr -d '"')
 RESULT_VER := $(shell grep -m1 cpp-result cabin.toml | sed 's/.*tag = \(.*\)}/\1/' | tr -d '"')
 
 DEFINES := -DCABIN_CABIN_PKG_VERSION='"$(VERSION)"' \

--- a/cabin.toml
+++ b/cabin.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/cabinpkg/cabin"
 version = "0.12.1"
 
 [dependencies]
-toml11 = {git = "https://github.com/ToruNiina/toml11.git", rev = "fdd5e29f78eb9e58cc02736f2dc4263ed0058662"}
+toml11 = {git = "https://github.com/ToruNiina/toml11.git", tag = "v4.4.0"}
 mitama-cpp-result = {git = "https://github.com/loliGothicK/mitama-cpp-result.git", tag = "v11.0.0"}
 fmt = {version = ">=9 && <12", system = true}
 spdlog = {version = ">=1.8 && <2", system = true}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the dependency versioning process to use a stable version tag rather than a commit-specific reference. This improvement enhances build consistency and ensures reliable tracking of external software versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->