### PR TITLE
Project: move paths from BuildConfig

### DIFF
--- a/src/BuildConfig.hpp
+++ b/src/BuildConfig.hpp
@@ -57,10 +57,9 @@ public:
 
 private:
   const Manifest& manifest;
-  std::string libName;
-  fs::path buildOutPath;
-  fs::path unittestOutPath;
+  Project project;
   BuildProfile buildProfile;
+  std::string libName;
 
   // if we are building an binary
   bool hasBinaryTarget{ false };
@@ -74,8 +73,6 @@ private:
   std::optional<std::unordered_set<std::string>> phony;
   std::optional<std::unordered_set<std::string>> all;
 
-  Project project;
-
   bool isUpToDate(std::string_view fileName) const;
   std::string mapHeaderToObj(
       const fs::path& headerPath, const fs::path& buildOutPath
@@ -83,13 +80,11 @@ private:
 
   explicit BuildConfig(
       const Manifest& manifest, BuildProfile buildProfile, std::string libName,
-      fs::path outBasePath, fs::path buildOutPath, fs::path unittestOutPath,
       Project project
   )
-      : outBasePath(std::move(outBasePath)), manifest(manifest),
-        libName(std::move(libName)), buildOutPath(std::move(buildOutPath)),
-        unittestOutPath(std::move(unittestOutPath)),
-        buildProfile(std::move(buildProfile)), project(std::move(project)) {}
+      : outBasePath(project.outBasePath), manifest(manifest),
+        project(std::move(project)), buildProfile(std::move(buildProfile)),
+        libName(std::move(libName)) {}
 
 public:
   static Result<BuildConfig>

--- a/src/Builder/Project.cc
+++ b/src/Builder/Project.cc
@@ -78,7 +78,10 @@ getEnvFlags(const char* name) {
 }
 
 Project::Project(const BuildProfile& buildProfile, Manifest m, Compiler c)
-    : rootPath(m.path.parent_path()), manifest(std::move(m)),
+    : rootPath(m.path.parent_path()),
+      outBasePath(rootPath / "cabin-out" / fmt::format("{}", buildProfile)),
+      buildOutPath(outBasePath / (m.package.name + ".d")),
+      unittestOutPath(outBasePath / "unittests"), manifest(std::move(m)),
       compiler(std::move(c))  //
 {
   includeIfExist(rootPath / "src", /*isSystem=*/false);

--- a/src/Builder/Project.hpp
+++ b/src/Builder/Project.hpp
@@ -20,6 +20,9 @@ class Project {
 
 public:
   const fs::path rootPath;
+  const fs::path outBasePath;
+  const fs::path buildOutPath;
+  const fs::path unittestOutPath;
   const Manifest manifest;
   Compiler compiler;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined output directory management by relying on centralized project properties, eliminating redundancies.
  - Updated configuration setup with revised constructor parameters and member reordering for improved clarity and consistency.
  - Expanded the project interface to include dedicated properties for handling output paths related to builds and unittests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->