### PR TITLE
BuildConfig: remove manifest and use project.manifest

### DIFF
--- a/src/BuildConfig.hpp
+++ b/src/BuildConfig.hpp
@@ -56,7 +56,6 @@ public:
   fs::path outBasePath;
 
 private:
-  const Manifest& manifest;
   Project project;
   BuildProfile buildProfile;
   std::string libName;
@@ -79,12 +78,10 @@ private:
   ) const;
 
   explicit BuildConfig(
-      const Manifest& manifest, BuildProfile buildProfile, std::string libName,
-      Project project
+      BuildProfile buildProfile, std::string libName, Project project
   )
-      : outBasePath(project.outBasePath), manifest(manifest),
-        project(std::move(project)), buildProfile(std::move(buildProfile)),
-        libName(std::move(libName)) {}
+      : outBasePath(project.outBasePath), project(std::move(project)),
+        buildProfile(std::move(buildProfile)), libName(std::move(libName)) {}
 
 public:
   static Result<BuildConfig>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved the project build configuration by centralizing initialization and streamlining path resolutions.
	- Enhanced dependency installation and build setup logic for greater consistency.
	- Simplified the configuration interface by removing redundant parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->