### PR TITLE
remove unneeded semicolon

### DIFF
--- a/src/CurlVersion.hpp
+++ b/src/CurlVersion.hpp
@@ -14,7 +14,7 @@ struct Version {
   std::string toString() const;
 };
 
-};  // namespace curl
+}  // namespace curl
 
 template <>
 struct fmt::formatter<curl::Version> : formatter<std::string> {

--- a/src/Dependency.hpp
+++ b/src/Dependency.hpp
@@ -41,7 +41,7 @@ struct SystemDependency {
   Result<CompilerOpts> install() const;
 
   SystemDependency(std::string name, VersionReq versionReq)
-      : name(std::move(name)), versionReq(std::move(versionReq)) {};
+      : name(std::move(name)), versionReq(std::move(versionReq)) {}
 };
 
 using Dependency =


### PR DESCRIPTION
Though it is allowed to place extra semicolons as *empty-declaration*, they are not consistent with other code.