### PR TITLE
lint, fmt: implement flag --no-ignore-vcs

### DIFF
--- a/src/Cmd/Lint.cc
+++ b/src/Cmd/Lint.cc
@@ -13,6 +13,7 @@
 #include <spdlog/spdlog.h>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace cabin {
@@ -103,7 +104,7 @@ lintMain(const CliArgsView args) {
 
   const auto manifest = Try(Manifest::tryParse());
 
-  std::vector<std::string> cpplintArgs = lintArgs.excludes;
+  std::vector<std::string> cpplintArgs = std::move(lintArgs.excludes);
   if (fs::exists("CPPLINT.cfg")) {
     spdlog::debug("Using CPPLINT.cfg for lint ...");
     return lint(manifest.package.name, cpplintArgs, excludeVcsIgnored);


### PR DESCRIPTION
closes https://github.com/cabinpkg/cabin/issues/968, closes https://github.com/cabinpkg/cabin/issues/969


<!--
Complete the following checklist and remove it from the description.
-->

## Checklist

- [ ] Did you follow [CONTRIBUTING.md](https://github.com/cabinpkg/cabin/blob/main/CONTRIBUTING.md)?
- [ ] Did you follow [Pull Request Style](https://github.com/cabinpkg/cabin/blob/main/CONTRIBUTING.md#pull-request-style)?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `--no-ignore-vcs` option to the format and lint commands, allowing inclusion of files ignored by version control systems during formatting and linting.

- **Bug Fixes**
  - Improved file selection to respect the new option for including version control ignored files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->