### PR TITLE
INSTALL.md: add spdlog

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -45,6 +45,10 @@ You will require the following compilers, commands, and libraries:
     * `libtbb-dev` on APT (Debian/Ubuntu)
     * `tbb-devel` on DNF (Fedora)
     * `tbb` on Homebrew
+* spdlog `>=1.8.0 && <2.0.0`
+    * `libspdlog-dev` on APT (Debian/Ubuntu)
+    * `spdlog-devel` on DNF (Fedora)
+    * `spdlog` on Homebrew
 
 Installation scripts for libraries:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -45,7 +45,7 @@ You will require the following compilers, commands, and libraries:
     * `libtbb-dev` on APT (Debian/Ubuntu)
     * `tbb-devel` on DNF (Fedora)
     * `tbb` on Homebrew
-* spdlog `>=1.8.0 && <2.0.0`
+* spdlog: `>=1.8.0 && <2.0.0`
     * `libspdlog-dev` on APT (Debian/Ubuntu)
     * `spdlog-devel` on DNF (Fedora)
     * `spdlog` on Homebrew

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -64,7 +64,7 @@ Installation scripts for libraries:
 * Pacman (Arch/Manjaro):
   ```sh
   sudo pacman -Syu
-  sudo pacman -S fmt-devel libgit2-devel libcurl-devel json-devel tbb-devel spdlog-devel
+  sudo pacman -S fmt libgit2 curl nlohmann-json tbb spdlog
   ```
 * Homebrew:
   ```sh

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,20 +55,20 @@ Installation scripts for libraries:
 * APT (Debian/Ubuntu):
   ```sh
   sudo apt-get update
-  sudo apt-get install -y libfmt-dev libgit2-dev libcurl4-openssl-dev nlohmann-json3-dev libtbb-dev
+  sudo apt-get install -y libfmt-dev libgit2-dev libcurl4-openssl-dev nlohmann-json3-dev libtbb-dev libspdlog-dev
   ```
 * DNF (Fedora):
   ```sh
-  sudo dnf install -y fmt-devel libgit2-devel libcurl-devel json-devel tbb-devel
+  sudo dnf install -y fmt-devel libgit2-devel libcurl-devel json-devel tbb-devel spdlog-devel
   ```
 * Pacman (Arch/Manjaro):
   ```sh
   sudo pacman -Syu
-  sudo pacman -S fmt-devel libgit2-devel libcurl-devel json-devel tbb-devel
+  sudo pacman -S fmt-devel libgit2-devel libcurl-devel json-devel tbb-devel spdlog-devel
   ```
 * Homebrew:
   ```sh
-  brew install fmt libgit2 curl nlohmann-json tbb
+  brew install fmt libgit2 curl nlohmann-json tbb spdlog
   ```
 
 When running Make, the following libraries will be installed automatically.


### PR DESCRIPTION
fixes #1165, also fix issue with installation on pacman

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions to include the required `spdlog` library with specific version constraints.
  - Added package names for `spdlog` for APT, DNF, Pacman, and Homebrew.
  - Modified installation commands for all supported package managers to include `spdlog`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->