### PR TITLE
CI: bump clang-tidy to 20

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Build Cabin
         run: make RELEASE=1
 
-      - name: Install clang-format
+      - name: Install clang-format-20
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x ./llvm.sh
@@ -189,14 +189,14 @@ jobs:
       - name: Build Cabin
         run: make RELEASE=1
 
-      - name: Install clang-tidy
+      - name: Install clang-tidy-20
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x ./llvm.sh
-          sudo ./llvm.sh 19
-          sudo apt-get install -y clang-tidy-19
+          sudo ./llvm.sh 20
+          sudo apt-get install -y clang-tidy-20
 
       - name: cabin tidy
         run: ./build/cabin tidy --verbose
         env:
-          CABIN_TIDY: clang-tidy-19
+          CABIN_TIDY: clang-tidy-20


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated formatting and linting tools in the C++ workflow to use clang-format 20 and clang-tidy 20.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->