### PR TITLE
Supersedes #1171

### DIFF
--- a/src/Cmd/Lint.cc
+++ b/src/Cmd/Lint.cc
@@ -13,6 +13,7 @@
 #include <spdlog/spdlog.h>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace cabin {
@@ -108,7 +109,7 @@ lintMain(const CliArgsView args) {
 
   const auto manifest = Try(Manifest::tryParse());
 
-  std::vector<std::string> cpplintArgs = lintArgs.excludes;
+  std::vector<std::string> cpplintArgs = std::move(lintArgs.excludes);
   if (fs::exists("CPPLINT.cfg")) {
     spdlog::debug("Using CPPLINT.cfg for lint ...");
     return lint(manifest.package.name, cpplintArgs, useVcsIgnoreFiles);

--- a/src/Cmd/Lint.cc
+++ b/src/Cmd/Lint.cc
@@ -19,21 +19,30 @@ namespace cabin {
 
 static Result<void> lintMain(CliArgsView args);
 
-const Subcmd LINT_CMD = Subcmd{ "lint" }
-                            .setDesc("Lint codes using cpplint")
-                            .addOpt(
-                                Opt{ "--exclude" }
-                                    .setDesc("Exclude files from linting")
-                                    .setPlaceholder("<FILE>")
-                            )
-                            .setMainFn(lintMain);
+const Subcmd LINT_CMD =
+    Subcmd{ "lint" }
+        .setDesc("Lint codes using cpplint")
+        .addOpt(
+            Opt{ "--exclude" }
+                .setDesc("Exclude files from linting")
+                .setPlaceholder("<FILE>")
+        )
+        .addOpt(
+            Opt{ "--no-ignore-vcs" }.setDesc(
+                "Do not exclude git-ignored files from linting"
+            )
+        )
+        .setMainFn(lintMain);
 
 struct LintArgs {
   std::vector<std::string> excludes;
 };
 
 static Result<void>
-lint(const std::string_view name, const std::vector<std::string>& cpplintArgs) {
+lint(
+    const std::string_view name, const std::vector<std::string>& cpplintArgs,
+    bool useVcsIgnoreFiles
+) {
   Diag::info("Linting", "{}", name);
 
   Command cpplintCmd("cpplint", cpplintArgs);
@@ -41,8 +50,8 @@ lint(const std::string_view name, const std::vector<std::string>& cpplintArgs) {
     cpplintCmd.addArg("--quiet");
   }
 
-  // Read .gitignore if exists
-  if (fs::exists(".gitignore")) {
+  // If gitignored files need to be ignored, read .gitignore if exists
+  if (useVcsIgnoreFiles && fs::exists(".gitignore")) {
     std::ifstream ifs(".gitignore");
     std::string line;
     while (std::getline(ifs, line)) {
@@ -68,6 +77,7 @@ lint(const std::string_view name, const std::vector<std::string>& cpplintArgs) {
 static Result<void>
 lintMain(const CliArgsView args) {
   LintArgs lintArgs;
+  bool useVcsIgnoreFiles = true;
   for (auto itr = args.begin(); itr != args.end(); ++itr) {
     const std::string_view arg = *itr;
 
@@ -82,6 +92,8 @@ lintMain(const CliArgsView args) {
       }
 
       lintArgs.excludes.push_back("--exclude=" + std::string(*++itr));
+    } else if (arg == "--no-ignore-vcs") {
+      useVcsIgnoreFiles = false;
     } else {
       return LINT_CMD.noSuchArg(arg);
     }
@@ -99,7 +111,7 @@ lintMain(const CliArgsView args) {
   std::vector<std::string> cpplintArgs = lintArgs.excludes;
   if (fs::exists("CPPLINT.cfg")) {
     spdlog::debug("Using CPPLINT.cfg for lint ...");
-    return lint(manifest.package.name, cpplintArgs);
+    return lint(manifest.package.name, cpplintArgs, useVcsIgnoreFiles);
   }
 
   if (fs::exists("include")) {
@@ -120,14 +132,14 @@ lintMain(const CliArgsView args) {
     // Remove last comma
     filterArg.pop_back();
     cpplintArgs.push_back(filterArg);
-    return lint(manifest.package.name, cpplintArgs);
+    return lint(manifest.package.name, cpplintArgs, useVcsIgnoreFiles);
   } else {
     spdlog::debug("Using default arguments for lint ...");
     if (Edition::Cpp11 < manifest.package.edition) {
       // Disable C++11-related lints
       cpplintArgs.emplace_back("--filter=-build/c++11");
     }
-    return lint(manifest.package.name, cpplintArgs);
+    return lint(manifest.package.name, cpplintArgs, useVcsIgnoreFiles);
   }
 }
 


### PR DESCRIPTION
closes #1171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new command-line option `--no-ignore-vcs` to the format and lint commands, enabling users to include files normally excluded by version control ignore rules during formatting and linting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->