### PR TITLE
Fix: ensure lexer position is valid before parsing pre-release and bu…

### DIFF
--- a/src/VersionReq.cc
+++ b/src/VersionReq.cc
@@ -1350,6 +1350,9 @@ testComparatorParse() {
 static void
 testLeadingDigitInPreAndBuild() {
   for (const auto& cmp : { "", "<", "<=", ">", ">=" }) {
+    // digit
+    assertTrue(VersionReq::parse(cmp + "1.2.3-1"s).is_ok());
+
     // digit then alpha
     assertTrue(VersionReq::parse(cmp + "1.2.3-1a"s).is_ok());
     assertTrue(VersionReq::parse(cmp + "1.2.3+1a"s).is_ok());

--- a/src/VersionReq.cc
+++ b/src/VersionReq.cc
@@ -128,14 +128,17 @@ struct ComparatorLexer {
       Try(parser.parseDot());
       ver.patch = Try(parser.parseNum());
 
-      if (parser.lexer.s[parser.lexer.pos] == '-') {
-        parser.lexer.step();
-        ver.pre = Try(parser.parsePre());
-      }
+      if (parser.lexer.pos < parser.lexer.s.size()) {
+        if (parser.lexer.s[parser.lexer.pos] == '-') {
+          parser.lexer.step();
+          ver.pre = Try(parser.parsePre());
+        }
 
-      if (parser.lexer.s[parser.lexer.pos] == '+') {
-        parser.lexer.step();
-        Try(parser.parseBuild());  // discard build metadata
+        if (parser.lexer.pos < parser.lexer.s.size()
+            && parser.lexer.s[parser.lexer.pos] == '+') {
+          parser.lexer.step();
+          Try(parser.parseBuild());  // discard build metadata
+        }
       }
 
       pos = parser.lexer.pos;


### PR DESCRIPTION
When cabin check invalid dep version string it crashes. The following PR check the length of the string before accessing it.

## Checklist

- [x] Did you follow [CONTRIBUTING.md](https://github.com/cabinpkg/cabin/blob/main/CONTRIBUTING.md)?
- [x] Did you follow [Pull Request Style](https://github.com/cabinpkg/cabin/blob/main/CONTRIBUTING.md#pull-request-style)?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability by adding boundary checks when parsing version strings, preventing potential errors with malformed input.
  - Enhanced version parsing to correctly handle versions with leading digits in pre-release segments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->