### PR TITLE
Manifest: comp-db -> compdb

### DIFF
--- a/cabin.toml
+++ b/cabin.toml
@@ -24,7 +24,7 @@ tbb = {version = ">=2021.5.0 && <2023.0.0", system = true}
 cxxflags = ["-pedantic-errors", "-Wall", "-Wextra", "-Wpedantic", "-fno-rtti"]
 
 [profile.dev]
-comp-db = true  # always build comp DB on dev
+compdb = true  # always build comp DB on dev
 
 [profile.release]
 lto = true

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -61,7 +61,7 @@ If you want to keep it updated as you build the project, you can update `cabin.t
 
 ```toml
 [profile.dev]
-comp-db = true  # always build comp DB on dev
+compdb = true  # always build comp DB on dev
 ```
 
 ## Install dependencies

--- a/src/Manifest.cc
+++ b/src/Manifest.cc
@@ -135,7 +135,7 @@ parseBaseProfile(const toml::value& val) noexcept {
   const mitama::maybe debug =
       toml::try_find<bool>(val, "profile", "debug").ok();
   const bool compDb =
-      toml::try_find<bool>(val, "profile", "comp-db").unwrap_or(false);
+      toml::try_find<bool>(val, "profile", "compdb").unwrap_or(false);
   const mitama::maybe optLevel =
       toml::try_find<std::uint8_t>(val, "profile", "opt-level").ok();
 
@@ -164,7 +164,7 @@ parseDevProfile(
       val, "profile", "dev", "debug", baseProfile.debug.unwrap_or(true)
   );
   const auto devCompDb =
-      toml::find_or<bool>(val, "profile", "dev", "comp-db", baseProfile.compDb);
+      toml::find_or<bool>(val, "profile", "dev", "compdb", baseProfile.compDb);
   const auto devOptLevel = Try(validateOptLevel(
       toml::find_or<std::uint8_t>(
           val, "profile", "dev", "opt-level", baseProfile.optLevel.unwrap_or(0)
@@ -198,7 +198,7 @@ parseReleaseProfile(
       val, "profile", "release", "debug", baseProfile.debug.unwrap_or(false)
   );
   const auto relCompDb = toml::find_or<bool>(
-      val, "profile", "release", "comp-db", baseProfile.compDb
+      val, "profile", "release", "compdb", baseProfile.compDb
   );
   const auto relOptLevel = Try(validateOptLevel(
       toml::find_or<std::uint8_t>(
@@ -834,7 +834,7 @@ testParseProfiles() {
       ldflags = ["-lm"]
       lto = true
       debug = true
-      comp-db = true
+      compdb = true
       opt-level = 2
     )"_toml;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the configuration key for enabling the compilation database in development profiles from "comp-db" to "compdb" for improved consistency.

* **Documentation**
  * Updated usage documentation to reflect the corrected configuration key name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->