### PR TITLE
RFC: feat: add support for -- to separate cabin args from program args

### DIFF
--- a/src/Cmd/Run.cc
+++ b/src/Cmd/Run.cc
@@ -30,8 +30,9 @@ const Subcmd RUN_CMD =
         .setDesc("Build and execute src/main.cc")
         .addOpt(OPT_RELEASE)
         .addOpt(OPT_JOBS)
-        .setArg(Arg{ "args" }
-                    .setDesc("Arguments passed to the program")
+        .setArg(Arg{ "[-- args]" }
+                    .setDesc("Arguments passed to the program (use -- to "
+                             "separate cabin options from program arguments)")
                     .setVariadic(true)
                     .setRequired(false))
         .setMainFn(runMain);
@@ -61,6 +62,10 @@ static Result<void> runMain(const CliArgsView args) {
           nextArg.data(), nextArg.data() + nextArg.size(), numThreads);
       Ensure(ec == std::errc(), "invalid number of threads: {}", nextArg);
       setParallelism(numThreads);
+    } else if (arg == "--") {
+      // End of cabin options, everything after is for the program
+      ++itr;
+      break;
     } else {
       // Unknown argument is the start of the program arguments.
       break;

--- a/tests/06-run.sh
+++ b/tests/06-run.sh
@@ -40,17 +40,8 @@ test_expect_success 'cabin run -- passes arguments to program' '
     cd $OUT &&
     "$CABIN" new test_args &&
     cd test_args &&
-    cat >src/main.cc <<-EOF &&
-#include <iostream>
-int main(int argc, char* argv[]) {
-    std::cout << "argc=" << argc << std::endl;
-    for (int i = 1; i < argc; ++i) {
-        std::cout << "arg[" << i << "]=" << argv[i] << std::endl;
-    }
-    return 0;
-}
-EOF
-    "$CABIN" run -- --help --version foo 1>stdout 2>stderr &&
+    cp "$WHEREAMI/06-run/test_args.cc" src/main.cc &&
+    "$CABIN" run -- --help --version foo 1>stdout &&
     (
         cat >stdout_exp <<-EOF &&
 argc=4
@@ -68,17 +59,8 @@ test_expect_success 'cabin run without -- stops at first unknown arg' '
     cd $OUT &&
     "$CABIN" new test_args2 &&
     cd test_args2 &&
-    cat >src/main.cc <<-EOF &&
-#include <iostream>
-int main(int argc, char* argv[]) {
-    std::cout << "argc=" << argc << std::endl;
-    for (int i = 1; i < argc; ++i) {
-        std::cout << "arg[" << i << "]=" << argv[i] << std::endl;
-    }
-    return 0;
-}
-EOF
-    "$CABIN" run foo bar --release 1>stdout 2>stderr &&
+    cp "$WHEREAMI/06-run/test_args.cc" src/main.cc &&
+    "$CABIN" run foo bar --release 1>stdout &&
     (
         cat >stdout_exp <<-EOF &&
 argc=4

--- a/tests/06-run/test_args.cc
+++ b/tests/06-run/test_args.cc
@@ -1,0 +1,7 @@
+#include <iostream>
+int main(int argc, char* argv[]) {
+    std::cout << "argc=" << argc << '\n';
+    for (int i = 1; i < argc; ++i) {
+        std::cout << "arg[" << i << "]=" << argv[i] << '\n';
+    }
+}

--- a/tests/06-run/test_args.cc
+++ b/tests/06-run/test_args.cc
@@ -1,7 +1,7 @@
 #include <iostream>
 int main(int argc, char* argv[]) {
-    std::cout << "argc=" << argc << '\n';
-    for (int i = 1; i < argc; ++i) {
-        std::cout << "arg[" << i << "]=" << argv[i] << '\n';
-    }
+  std::cout << "argc=" << argc << '\n';
+  for (int i = 1; i < argc; ++i) {
+    std::cout << "arg[" << i << "]=" << argv[i] << '\n';
+  }
 }


### PR DESCRIPTION
When I wrote a program using --help, I found that cabin would always intercept it when doing `cabin run --help`. So following cargo's lead, I added `--`  to separate them.  So now you can run `cabin run -- --help` and it passes help to your program. I didn't remove the old functionality because I wasn't sure if you'd want that breaking change. 

I figured the code here is easier to start the discussion hence the rfc pr.