### PR TITLE
RFC: feat: `CABIN_TARGET_DIR` env var and `build.target-dir` config support

### DIFF
--- a/include/Builder/DepGraph.hpp
+++ b/include/Builder/DepGraph.hpp
@@ -15,15 +15,13 @@ namespace fs = std::filesystem;
 
 class DepGraph {
 public:
-  explicit DepGraph(fs::path rootPath) : rootPath(std::move(rootPath)) {}
+  explicit DepGraph(Manifest manifest) : rootManifest(std::move(manifest)) {}
 
-  rs::Result<void> resolve();
   rs::Result<BuildGraph>
   computeBuildGraph(const BuildProfile& buildProfile) const;
 
 private:
-  fs::path rootPath;
-  std::optional<Manifest> rootManifest;
+  Manifest rootManifest;
 };
 
 } // namespace cabin

--- a/include/Manifest.hpp
+++ b/include/Manifest.hpp
@@ -134,6 +134,8 @@ public:
   installDeps(bool includeDevDeps, const BuildProfile& buildProfile,
               bool suppressDepDiag = false) const;
 
+  Manifest withTargetDir(fs::path targetDir) const;
+
 private:
   Manifest(fs::path path, Package package, std::vector<Dependency> dependencies,
            std::vector<Dependency> devDependencies,

--- a/include/Manifest.hpp
+++ b/include/Manifest.hpp
@@ -119,6 +119,7 @@ public:
   const std::vector<Dependency> devDependencies;
   const std::unordered_map<BuildProfile, Profile> profiles;
   const Lint lint;
+  const fs::path targetDir;
 
   static rs::Result<Manifest> tryParse(fs::path path = fs::current_path()
                                                        / FILE_NAME,
@@ -136,12 +137,13 @@ public:
 private:
   Manifest(fs::path path, Package package, std::vector<Dependency> dependencies,
            std::vector<Dependency> devDependencies,
-           std::unordered_map<BuildProfile, Profile> profiles,
-           Lint lint) noexcept
+           std::unordered_map<BuildProfile, Profile> profiles, Lint lint,
+           fs::path targetDir) noexcept
       : path(std::move(path)), package(std::move(package)),
         dependencies(std::move(dependencies)),
         devDependencies(std::move(devDependencies)),
-        profiles(std::move(profiles)), lint(std::move(lint)) {}
+        profiles(std::move(profiles)), lint(std::move(lint)),
+        targetDir(std::move(targetDir)) {}
 };
 
 rs::Result<void> validatePackageName(std::string_view name) noexcept;

--- a/lib/Builder/DepGraph.cc
+++ b/lib/Builder/DepGraph.cc
@@ -4,16 +4,9 @@
 
 namespace cabin {
 
-rs::Result<void> DepGraph::resolve() {
-  rootManifest.emplace(
-      rs_try(Manifest::tryParse(rootPath / Manifest::FILE_NAME)));
-  return rs::Ok();
-}
-
 rs::Result<BuildGraph>
 DepGraph::computeBuildGraph(const BuildProfile& buildProfile) const {
-  rs_ensure(rootManifest.has_value(), "dependency graph not resolved");
-  return BuildGraph::create(*rootManifest, buildProfile);
+  return BuildGraph::create(rootManifest, buildProfile);
 }
 
 } // namespace cabin

--- a/lib/Manifest.cc
+++ b/lib/Manifest.cc
@@ -628,6 +628,19 @@ parseSystemDep(const std::string& name, const toml::table& info) noexcept {
   return rs::Ok(SystemDependency(name, rs_try(VersionReq::parse(versionReq))));
 }
 
+static rs::Result<fs::path> parseTargetDir(const toml::value& val,
+                                           const char* key) noexcept {
+  const auto targetDir = toml::try_find<std::string>(val, key, "target-dir");
+  if (!targetDir.is_err()) {
+    spdlog::debug("[{}] not found or not a table", key);
+    return rs::Ok(targetDir.unwrap());
+  }
+  if (const char* env = std::getenv("CABIN_TARGET_DIR")) {
+    return rs::Ok(std::string(env));
+  }
+  return rs::Ok(fs::path("cabin-out"));
+}
+
 static rs::Result<std::vector<Dependency>>
 parseDependencies(const toml::value& val, const char* key) noexcept {
   const auto tomlDeps = toml::try_find<toml::table>(val, key);
@@ -678,9 +691,12 @@ rs::Result<Manifest> Manifest::tryFromToml(const toml::value& data,
       rs_try(parseProfiles(data));
   auto lint = rs_try(Lint::tryFromToml(data));
 
+  auto targetDir = rs_try(parseTargetDir(data, "build"));
+
   return rs::Ok(Manifest(std::move(path), std::move(package),
                          std::move(dependencies), std::move(devDependencies),
-                         std::move(profiles), std::move(lint)));
+                         std::move(profiles), std::move(lint),
+                         std::move(targetDir)));
 }
 
 rs::Result<fs::path> Manifest::findPath(fs::path candidateDir) noexcept {

--- a/lib/Manifest.cc
+++ b/lib/Manifest.cc
@@ -681,9 +681,8 @@ rs::Result<Manifest> Manifest::tryParse(fs::path path,
 }
 
 Manifest Manifest::withTargetDir(fs::path targetDir) const {
-  return Manifest(std::move(path), std::move(package), std::move(dependencies),
-                  std::move(devDependencies), std::move(profiles),
-                  std::move(lint), std::move(targetDir));
+  return Manifest{ path,     package, dependencies,        devDependencies,
+                   profiles, lint,    std::move(targetDir) };
 }
 
 rs::Result<Manifest> Manifest::tryFromToml(const toml::value& data,

--- a/lib/Manifest.cc
+++ b/lib/Manifest.cc
@@ -139,7 +139,7 @@ installPathDependency(const Manifest& manifest, const PathDependency& pathDep,
                depRoot.string());
   }
 
-  Builder depBuilder(depRoot, buildProfile);
+  Builder depBuilder(depManifest, buildProfile);
   ScheduleOptions depOptions;
   depOptions.includeDevDeps = includeDevDeps;
   depOptions.suppressAnalysisLog = true;
@@ -678,6 +678,12 @@ rs::Result<Manifest> Manifest::tryParse(fs::path path,
     path = rs_try(findPath(path.parent_path()));
   }
   return tryFromToml(toml::parse(path), path);
+}
+
+Manifest Manifest::withTargetDir(fs::path targetDir) const {
+  return Manifest(std::move(path), std::move(package), std::move(dependencies),
+                  std::move(devDependencies), std::move(profiles),
+                  std::move(lint), std::move(targetDir));
 }
 
 rs::Result<Manifest> Manifest::tryFromToml(const toml::value& data,

--- a/src/Builder/Builder.cc
+++ b/src/Builder/Builder.cc
@@ -15,14 +15,14 @@
 
 namespace cabin {
 
-Builder::Builder(fs::path rootPath, BuildProfile buildProfile)
-    : basePath(std::move(rootPath)), buildProfile(std::move(buildProfile)),
-      depGraph(basePath) {}
+Builder::Builder(Manifest rootManifest, BuildProfile buildProfile)
+    : basePath(rootManifest.path.parent_path()),
+      buildProfile(std::move(buildProfile)), depGraph(std::move(rootManifest)) {
+}
 
 rs::Result<void> Builder::schedule(const ScheduleOptions& options) {
   this->options = options;
 
-  rs_try(depGraph.resolve());
   graphState.emplace(rs_try(depGraph.computeBuildGraph(buildProfile)));
 
   const bool logAnalysis = !options.suppressAnalysisLog;

--- a/src/Builder/Builder.hpp
+++ b/src/Builder/Builder.hpp
@@ -24,7 +24,7 @@ struct ScheduleOptions {
 
 class Builder {
 public:
-  Builder(fs::path rootPath, BuildProfile buildProfile);
+  Builder(Manifest rootManifest, BuildProfile buildProfile);
 
   rs::Result<void> schedule(const ScheduleOptions& options = {});
   rs::Result<void> build();

--- a/src/Builder/Project.cc
+++ b/src/Builder/Project.cc
@@ -6,6 +6,7 @@
 #include "TermColor.hpp"
 
 #include <filesystem>
+#include <ranges>
 #include <rs/result.hpp>
 #include <spdlog/spdlog.h>
 #include <string>
@@ -78,7 +79,7 @@ static std::vector<std::string> getEnvFlags(const char* name) {
 Project::Project(const BuildProfile& buildProfile, Manifest m,
                  CompilerOpts opts)
     : rootPath(m.path.parent_path()),
-      outBasePath(rootPath / "cabin-out" / fmt::format("{}", buildProfile)),
+      outBasePath(rootPath / m.targetDir / fmt::format("{}", buildProfile)),
       buildOutPath(outBasePath / (m.package.name + ".d")),
       unittestOutPath(outBasePath / "unit"),
       integrationTestOutPath(outBasePath / "intg"), manifest(std::move(m)),

--- a/src/Cmd/Build.cc
+++ b/src/Cmd/Build.cc
@@ -19,6 +19,7 @@
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <utility>
 #include <vector>
 
 namespace cabin {
@@ -75,10 +76,10 @@ static rs::Result<void> buildMain(const CliArgsView args) {
     }
   }
 
-  const Manifest manifest = [targetDir](const Manifest m) -> Manifest {
+  const Manifest manifest = [targetDir](const Manifest& m) -> Manifest {
     return targetDir.has_value() ? m.withTargetDir(targetDir.value()) : m;
   }(rs_try(Manifest::tryParse()));
-  Builder builder(std::move(manifest), buildProfile);
+  Builder builder(manifest, buildProfile);
   rs_try(builder.schedule());
 
   if (buildCompdb) {

--- a/src/Cmd/Build.cc
+++ b/src/Cmd/Build.cc
@@ -33,12 +33,14 @@ const Subcmd BUILD_CMD =
         .addOpt(Opt{ "--compdb" }.setDesc(
             "Generate compilation database instead of building"))
         .addOpt(OPT_JOBS)
+        .addOpt(OPT_TARGET_DIR)
         .setMainFn(buildMain);
 
 static rs::Result<void> buildMain(const CliArgsView args) {
   // Parse args
   BuildProfile buildProfile = BuildProfile::Dev;
   bool buildCompdb = false;
+  std::optional<std::string_view> targetDir;
   for (auto itr = args.begin(); itr != args.end(); ++itr) {
     const std::string_view arg = *itr;
 
@@ -63,13 +65,20 @@ static rs::Result<void> buildMain(const CliArgsView args) {
           std::from_chars(nextArg.begin(), nextArg.end(), numThreads);
       rs_ensure(ec == std::errc(), "invalid number of threads: {}", nextArg);
       setParallelism(numThreads);
+    } else if (arg == "--target-dir") {
+      if (itr + 1 == args.end()) {
+        return Subcmd::missingOptArgumentFor(arg);
+      }
+      targetDir.emplace(*++itr);
     } else {
       return BUILD_CMD.noSuchArg(arg);
     }
   }
 
-  const Manifest manifest = rs_try(Manifest::tryParse());
-  Builder builder(manifest.path.parent_path(), buildProfile);
+  const Manifest manifest = [targetDir](const Manifest m) -> Manifest {
+    return targetDir.has_value() ? m.withTargetDir(targetDir.value()) : m;
+  }(rs_try(Manifest::tryParse()));
+  Builder builder(std::move(manifest), buildProfile);
   rs_try(builder.schedule());
 
   if (buildCompdb) {

--- a/src/Cmd/Common.hpp
+++ b/src/Cmd/Common.hpp
@@ -20,4 +20,10 @@ inline const Opt OPT_JOBS =
         .setPlaceholder("<NUM>")
         .setDefault(NUM_DEFAULT_THREADS);
 
+inline const Opt OPT_TARGET_DIR =
+    Opt{ "--target-dir" }
+        .setDesc(
+            "Set directory for all generated artifacts and intermediate files")
+        .setPlaceholder("<DIRECTORY>");
+
 } // namespace cabin

--- a/src/Cmd/Run.cc
+++ b/src/Cmd/Run.cc
@@ -30,6 +30,7 @@ const Subcmd RUN_CMD =
         .setDesc("Build and execute src/main.cc")
         .addOpt(OPT_RELEASE)
         .addOpt(OPT_JOBS)
+        .addOpt(OPT_TARGET_DIR)
         .setArg(Arg{ "args" }
                     .setDesc("Arguments passed to the program")
                     .setVariadic(true)
@@ -40,6 +41,7 @@ static rs::Result<void> runMain(const CliArgsView args) {
   // Parse args
   BuildProfile buildProfile = BuildProfile::Dev;
   auto itr = args.begin();
+  std::optional<std::string_view> targetDir;
   for (; itr != args.end(); ++itr) {
     const std::string_view arg = *itr;
 
@@ -61,6 +63,11 @@ static rs::Result<void> runMain(const CliArgsView args) {
           std::from_chars(nextArg.begin(), nextArg.end(), numThreads);
       rs_ensure(ec == std::errc(), "invalid number of threads: {}", nextArg);
       setParallelism(numThreads);
+    } else if (arg == "--target-dir") {
+      if (itr + 1 == args.end()) {
+        return Subcmd::missingOptArgumentFor(arg);
+      }
+      targetDir.emplace(*++itr);
     } else {
       // Unknown argument is the start of the program arguments.
       break;
@@ -72,8 +79,10 @@ static rs::Result<void> runMain(const CliArgsView args) {
     runArgs.emplace_back(*itr);
   }
 
-  const auto manifest = rs_try(Manifest::tryParse());
-  Builder builder(manifest.path.parent_path(), buildProfile);
+  const Manifest manifest = [targetDir](const Manifest m) -> Manifest {
+    return targetDir.has_value() ? m.withTargetDir(targetDir.value()) : m;
+  }(rs_try(Manifest::tryParse()));
+  Builder builder(std::move(manifest), buildProfile);
   rs_try(builder.schedule());
   rs_try(builder.build());
 

--- a/src/Cmd/Run.cc
+++ b/src/Cmd/Run.cc
@@ -18,6 +18,7 @@
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <utility>
 #include <vector>
 
 namespace cabin {
@@ -79,10 +80,10 @@ static rs::Result<void> runMain(const CliArgsView args) {
     runArgs.emplace_back(*itr);
   }
 
-  const Manifest manifest = [targetDir](const Manifest m) -> Manifest {
+  const Manifest manifest = [targetDir](const Manifest& m) -> Manifest {
     return targetDir.has_value() ? m.withTargetDir(targetDir.value()) : m;
   }(rs_try(Manifest::tryParse()));
-  Builder builder(std::move(manifest), buildProfile);
+  Builder builder(manifest, buildProfile);
   rs_try(builder.schedule());
   rs_try(builder.build());
 

--- a/src/Cmd/Test.cc
+++ b/src/Cmd/Test.cc
@@ -26,6 +26,7 @@ const Subcmd TEST_CMD = //
         .setShort("t")
         .setDesc("Run the tests of a local package")
         .addOpt(OPT_JOBS)
+        .addOpt(OPT_TARGET_DIR)
         .addOpt(Opt{ "--coverage" }.setDesc("Enable code coverage analysis"))
         .setArg(
             Arg{ "TESTNAME" }.setRequired(false).setDesc("Test name to launch"))
@@ -34,6 +35,7 @@ const Subcmd TEST_CMD = //
 static rs::Result<void> testMain(const CliArgsView args) {
   bool enableCoverage = false;
   std::optional<std::string> testName;
+  std::optional<std::string_view> targetDir;
 
   for (auto itr = args.begin(); itr != args.end(); ++itr) {
     const std::string_view arg = *itr;
@@ -60,13 +62,20 @@ static rs::Result<void> testMain(const CliArgsView args) {
       enableCoverage = true;
     } else if (!testName) {
       testName = arg;
+    } else if (arg == "--target-dir") {
+      if (itr + 1 == args.end()) {
+        return Subcmd::missingOptArgumentFor(arg);
+      }
+      targetDir.emplace(*++itr);
     } else {
       return TEST_CMD.noSuchArg(arg);
     }
   }
 
-  const Manifest manifest = rs_try(Manifest::tryParse());
-  Builder builder(manifest.path.parent_path(), BuildProfile::Test);
+  const Manifest manifest = [targetDir](const Manifest m) -> Manifest {
+    return targetDir.has_value() ? m.withTargetDir(targetDir.value()) : m;
+  }(rs_try(Manifest::tryParse()));
+  Builder builder(std::move(manifest), BuildProfile::Test);
   rs_try(builder.schedule(ScheduleOptions{ .includeDevDeps = true,
                                            .enableCoverage = enableCoverage }));
   return builder.test(std::move(testName));

--- a/src/Cmd/Test.cc
+++ b/src/Cmd/Test.cc
@@ -72,10 +72,10 @@ static rs::Result<void> testMain(const CliArgsView args) {
     }
   }
 
-  const Manifest manifest = [targetDir](const Manifest m) -> Manifest {
+  const Manifest manifest = [targetDir](const Manifest& m) -> Manifest {
     return targetDir.has_value() ? m.withTargetDir(targetDir.value()) : m;
   }(rs_try(Manifest::tryParse()));
-  Builder builder(std::move(manifest), BuildProfile::Test);
+  Builder builder(manifest, BuildProfile::Test);
   rs_try(builder.schedule(ScheduleOptions{ .includeDevDeps = true,
                                            .enableCoverage = enableCoverage }));
   return builder.test(std::move(testName));

--- a/src/Cmd/Test.cc
+++ b/src/Cmd/Test.cc
@@ -60,13 +60,13 @@ static rs::Result<void> testMain(const CliArgsView args) {
       setParallelism(numThreads);
     } else if (arg == "--coverage") {
       enableCoverage = true;
-    } else if (!testName) {
-      testName = arg;
     } else if (arg == "--target-dir") {
       if (itr + 1 == args.end()) {
         return Subcmd::missingOptArgumentFor(arg);
       }
       targetDir.emplace(*++itr);
+    } else if (!testName) {
+      testName = arg;
     } else {
       return TEST_CMD.noSuchArg(arg);
     }

--- a/src/Cmd/Tidy.cc
+++ b/src/Cmd/Tidy.cc
@@ -93,7 +93,7 @@ static rs::Result<void> tidyMain(const CliArgsView args) {
                                               BuildProfile::Test };
   bool isFirstProfile = true;
   for (const BuildProfile& profile : profiles) {
-    Builder builder(projectRoot, profile);
+    Builder builder(manifest, profile);
     const bool includeDevDeps = (profile == BuildProfile::Test);
     rs_try(builder.schedule(ScheduleOptions{
         .includeDevDeps = includeDevDeps,

--- a/tests/build.cc
+++ b/tests/build.cc
@@ -6,6 +6,15 @@ int main() {
   using boost::ut::expect;
   using boost::ut::operator""_test;
 
+  "cabin build uses cli target-dir"_test = [] {
+    const tests::TempDir tmp;
+    tests::runCabin({ "new", "hello_world" }, tmp.path).unwrap();
+    const auto project = tmp.path / "hello_world";
+
+    tests::runCabin({ "build", "--target-dir", "tmpdir" }, project).unwrap();
+    expect(tests::fs::is_directory(project / "tmpdir" / "dev"));
+  };
+
   "cabin build emits ninja"_test = [] {
     const tests::TempDir tmp;
     tests::runCabin({ "new", "ninja_project" }, tmp.path).unwrap();

--- a/tests/run.cc
+++ b/tests/run.cc
@@ -9,6 +9,15 @@ int main() {
   using boost::ut::expect;
   using boost::ut::operator""_test;
 
+  "cabin run uses cli target-dir"_test = [] {
+    const tests::TempDir tmp;
+    tests::runCabin({ "new", "hello_world" }, tmp.path).unwrap();
+    const auto project = tmp.path / "hello_world";
+
+    tests::runCabin({ "run", "--target-dir", "tmpdir" }, project).unwrap();
+    expect(tests::fs::is_directory(project / "tmpdir" / "dev"));
+  };
+
   "cabin run"_test = [] {
     const tests::TempDir tmp;
     tests::runCabin({ "new", "hello_world" }, tmp.path).unwrap();

--- a/tests/test.cc
+++ b/tests/test.cc
@@ -80,6 +80,15 @@ int main() {
   using boost::ut::expect;
   using boost::ut::operator""_test;
 
+  "cabin test uses cli target-dir"_test = [] {
+    const tests::TempDir tmp;
+    tests::runCabin({ "new", "hello_world" }, tmp.path).unwrap();
+    const auto project = tmp.path / "hello_world";
+
+    tests::runCabin({ "test", "--target-dir", "tmpdir" }, project).unwrap();
+    expect(tests::fs::is_directory(project / "tmpdir" / "test"));
+  };
+
   "cabin test basic"_test = [] {
     const tests::TempDir tmp;
     tests::runCabin({ "new", "test_project" }, tmp.path).unwrap();


### PR DESCRIPTION
# Target Directory Overriding

 I am basing the usage on [the way cargo does it](https://doc.rust-lang.org/cargo/commands/cargo-build.html).

So far I updated Manifest to read from the `CABIN_TARGET_DIRECTORY` environment variable and the `build.target-dir` configuration, falling back on the default of `cabin-out` if neither value has been set. Project was updated to read the value from Manifest instead of using the hard-coded value.

~~I do plan to add support for the `--target-dir` cli option as well, but as-of-yet that is not done.~~

The `--target-dir` cli option has been added to `run`, `build` and `test`. Since Manifest is const, I added `Manifest::withTargetDir()` to create a copy with the new value. This also means when Manifest needs to be modified after creation (in Build.cc/Run.cc/Test.cc) they do so in a lamda so that the variable can stay const.

I did change DepGraph to receive a Manifest directly rather than a path that is then resolved. This was done because I needed the updated Manifest to get propagated through the graph. It seemed like a safe change, but I don't know why it was designed this was originally so I could well be missing something.

Thoughts?

<!--
Complete the following checklist and remove it from the description.
-->

## Checklist

- [x] Did you follow [CONTRIBUTING.md](https://github.com/cabinpkg/cabin/blob/main/CONTRIBUTING.md)?
- [x] Did you follow [Pull Request Style](https://github.com/cabinpkg/cabin/blob/main/CONTRIBUTING.md#pull-request-style)?
