### PR TITLE
docs(install): add package manager commands and cargo install

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,4 +1,6 @@
-# Installing Cabin from Source
+# Installation
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/cabin-cpp-package-manager.svg)](https://repology.org/project/cabin-cpp-package-manager/versions)
 
 The recommended way to get Cabin is from
 [the docs site](https://docs.cabinpkg.com/installation). Building from
@@ -8,11 +10,7 @@ to verify a build locally.
 If you intend to contribute back, read [CONTRIBUTING.md](CONTRIBUTING.md)
 instead — it covers the development workflow on top of the steps here.
 
-## Prerequisites
-
-- A [Rust toolchain](https://www.rust-lang.org/tools/install) on the
-  stable channel.
-- `git`.
+## Runtime Prerequisites
 
 The Cabin binary itself has no C / C++ build-time dependency. The
 C / C++ toolchains, Ninja, and the format / static-analysis helpers
@@ -20,7 +18,58 @@ are runtime requirements for `cabin build` / `cabin fmt` /
 `cabin tidy` and are documented in
 [Installation: Runtime Requirements](https://docs.cabinpkg.com/installation).
 
-## Build
+## Package Managers
+
+### Linux
+
+```console
+# Arch Linux
+paru -S cabin
+
+# Nix/NixOS
+nix-env -i cabinpkg
+
+# Termux
+pkg install cabin
+```
+
+### macOS
+
+```console
+# Homebrew
+brew install cabin
+```
+
+### Windows
+
+Unsupported, see [architecture](docs/architecture.md).
+
+You may build from source with instructions found below.
+
+## Manual Download
+
+### Github Releases
+
+You can download prebuilt binaries from the [github releases section](https://github.com/cabinpkg/cabin/releases).
+
+## Building from Source
+
+### Prerequisites
+
+- [Rust toolchain](https://www.rust-lang.org/tools/install) on the
+  stable channel
+- `git`
+
+### Cargo
+
+You can build and install from source with Cargo
+```console
+cargo install --git https://github.com/cabinpkg/cabin.git cabin-cli
+```
+
+Cabin lands at `~/.cargo/bin/cabin`. Make sure it's in your `$PATH`.
+
+### Source Code
 
 ```sh
 git clone https://github.com/cabinpkg/cabin
@@ -35,7 +84,7 @@ directory on your `$PATH`, or run it directly:
 ./target/release/cabin --version
 ```
 
-## Updating
+Updating is done with:
 
 ```sh
 git pull

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -64,7 +64,7 @@ You can download prebuilt binaries from the [github releases section](https://gi
 
 You can build and install from source with Cargo
 ```console
-cargo install --git https://github.com/cabinpkg/cabin.git cabin-cli
+cargo install --git https://github.com/cabinpkg/cabin.git --locked --bin cabin-cli
 ```
 
 Cabin lands at `~/.cargo/bin/cabin`. Make sure it's in your `$PATH`.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,6 +20,9 @@ are runtime requirements for `cabin build` / `cabin fmt` /
 
 ## Package Managers
 
+Note: packages can be community-maintained.
+Building from source is the recommended supported method.
+
 ### Linux
 
 ```console
@@ -27,7 +30,8 @@ are runtime requirements for `cabin build` / `cabin fmt` /
 paru -S cabin
 
 # Nix/NixOS
-nix-env -i cabinpkg
+nix-shell -p nixpkgs.cabin        # temporary
+nix profile install nixpkgs#cabin # per-use
 
 # Termux
 pkg install cabin

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -64,7 +64,7 @@ You can download prebuilt binaries from the [github releases section](https://gi
 
 You can build and install from source with Cargo
 ```console
-cargo install --git https://github.com/cabinpkg/cabin.git --locked --bin cabin-cli
+cargo install --git https://github.com/cabinpkg/cabin.git --locked cabin-cli
 ```
 
 Cabin lands at `~/.cargo/bin/cabin`. Make sure it's in your `$PATH`.

--- a/README.md
+++ b/README.md
@@ -11,10 +11,6 @@ It is designed for conventional C/C++ projects that want a simpler, more reprodu
 
 ## Installation
 
-Read ["Installation"](https://docs.cabinpkg.com/installation) from [Cabin Docs](https://docs.cabinpkg.com).
-
-## Installing from Source (*not recommended*)
-
 See [INSTALL.md](INSTALL.md).
 
 ## Community


### PR DESCRIPTION
- installing from package managers or direct binary download typically should not require a rust toolchain
- it's easier to have explicit commands, that can help less experienced users and save some context for agents

I'd recommend merge this after the rust binary releases are up on github